### PR TITLE
fetch_int -> from_integer; integer_representation -> to_integer

### DIFF
--- a/utilities.sage
+++ b/utilities.sage
@@ -10,7 +10,7 @@ implode_dict = { explode_table[i]:i for i in range(256)}
 
 def decode_vec(t, l):
     t = [(t[i//2] >> i % 2 * 4) & 0xf for i in range(2 * len(t))]
-    v = vector(map(F16.fetch_int, t))
+    v = vector(map(F16.from_integer, t))
 
     if l % 2 == 1:
         v = v[:-1]
@@ -21,8 +21,8 @@ def encode_vec(v):
         v  = vector(F16, v.list() + [ F16(0) ])
     bs = []
     for i in range(len(v)//2):
-        bs += [v[i*2].integer_representation() |
-               (v[i*2 + 1].integer_representation() << 4)]
+        bs += [v[i*2].to_integer() |
+               (v[i*2 + 1].to_integer() << 4)]
     return bytes(bs)
 
 def decode_matrix(t, rows, columns):
@@ -182,7 +182,7 @@ def bitsliced_add(veca, vecb):
 def bitsliced_mul_add(In, a, Out):
     In0, In1, In2, In3 = In
     Out0, Out1, Out2, Out3 = Out
-    a_int = a.integer_representation()
+    a_int = a.to_integer()
 
     if a_int & 1:
         Out0 ^^= In0


### PR DESCRIPTION
sage deprecated fetch_int and integer_representation in vesion 3.9: https://www.sagemath.org/changelogs/sage-9.8.txt.

I'm getting the following warning when running our code
```
/usr/lib/python3.12/site-packages/sage/structure/sequence.py:233: DeprecationWarning: fetch_int is deprecated. Please use from_integer instead.
See https://github.com/sagemath/sage/issues/33941 for details.
  x = list(x)  # make a copy even if x is a list, we're going to change it
/tmp/MAYO-sage/sagelib/utilities.py:29: DeprecationWarning: integer_representation is deprecated. Please use to_integer instead.
See https://github.com/sagemath/sage/issues/33941 for details.
  bs += [v[i*_sage_const_2 ].integer_representation() |
/tmp/MAYO-sage/sagelib/utilities.py:30: DeprecationWarning: integer_representation is deprecated. Please use to_integer instead.
See https://github.com/sagemath/sage/issues/33941 for details.
```



We should switch to from_integer to_integer.
Thanks yx7
